### PR TITLE
Feat: added .ipynb files for merge dset

### DIFF
--- a/utils/aihub_to_ufo_v2.ipynb
+++ b/utils/aihub_to_ufo_v2.ipynb
@@ -394,7 +394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.5 (default, Sep  4 2020, 07:30:14) \n[GCC 7.3.0]"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/utils/dataset_mix.ipynb
+++ b/utils/dataset_mix.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import os.path as osp\n",
+    "import json\n",
+    "import pprint\n",
+    "import distutils.dir_util as dir_util"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATASET_A_NAME = \"aihub_1\"\n",
+    "DATASET_B_NAME = \"ICDAR17_Korean\"\n",
+    "DATASET_NEW_NAME = \"ICDAR17_aihub_1__mix\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mixdataset(input_dset1_name, input_dset2_name, output_dset_name):\n",
+    "    # 새로운 data의 dir들을 만든다\n",
+    "    DEFAULT_PATH = \"/opt/ml/input/data\"\n",
+    "    input1_path = osp.join(DEFAULT_PATH, input_dset1_name)\n",
+    "    input2_path = osp.join(DEFAULT_PATH, input_dset2_name)\n",
+    "    output_path = osp.join(DEFAULT_PATH, output_dset_name)\n",
+    "    for dir_name in [\"images\", \"ufo\"]:\n",
+    "        path = osp.join(output_path, dir_name)\n",
+    "        os.makedirs(path, exist_ok=True)\n",
+    "    \n",
+    "    # json1, json2를 불러온다\n",
+    "    with open(osp.join(input1_path, \"ufo\", \"train.json\"), 'r') as f:\n",
+    "        json1 = json.load(f)\n",
+    "    with open(osp.join(input2_path, \"ufo\", \"train.json\"), 'r') as f:\n",
+    "        json2 = json.load(f)\n",
+    "\n",
+    "    # join해서 하나의 json을 만든다\n",
+    "    merged_json = {\"images\": {**json1[\"images\"], **json2[\"images\"]}}\n",
+    "\n",
+    "    # merged dict 파일 저장\n",
+    "    with open(osp.join(output_path, \"ufo\",\"train.json\"), 'w', encoding='utf-8') as f:\n",
+    "        json.dump(merged_json, f, indent=4)\n",
+    "\n",
+    "    src1 = osp.join(input1_path, \"images\")\n",
+    "    src2 = osp.join(input2_path, \"images\")\n",
+    "    dst = osp.join(output_path, \"images\")\n",
+    "    \n",
+    "    # 이미지 복사\n",
+    "    dir_util.copy_tree(src1, dst)\n",
+    "    dir_util.copy_tree(src2, dst)\n",
+    "\n",
+    "    print(f\"{input_dset1_name} 데이터셋의 이미지 개수\", len(os.listdir(src1)))\n",
+    "    print(f\"{input_dset2_name} 데이터셋의 이미지 개수\", len(os.listdir(src2)))\n",
+    "    print(f\"{output_dset_name} 데이터셋의 이미지 개수\", len(os.listdir(dst)))\n",
+    "\n",
+    "    return None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "aihub_1 데이터셋의 이미지 개수 13400\n",
+      "ICDAR17_Korean 데이터셋의 이미지 개수 536\n",
+      "ICDAR17_aihub_1__mix 데이터셋의 이미지 개수 13936\n"
+     ]
+    }
+   ],
+   "source": [
+    "mixdataset(DATASET_A_NAME, DATASET_B_NAME, DATASET_NEW_NAME)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "d4d1e4263499bec80672ea0156c357c1ee493ec2b1c70f0acce89fc37c4a6abe"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
2개의 데이터셋을 머지하는 기능을 추가했습니다.  
image와 annot를 이어주는 방식입니다.  
  
utils > `dataset_mix.ipynb`에서 파라미터 3개를 지정해주면 됩니다.  
`DATASET_A_NAME` = 합칠 데이터 폴더명1  
`DATASET_B_NAME` = 합칠 데이터 폴더명2  
`DATASET_NEW_NAME` = 머지된 데이터의 폴더명  

아직 정상 학습가능여부는 확인 안해봤습니다.  
버그가 있을경우 dev branch에서 수정하겠습니다.  